### PR TITLE
2023-07-07 00:07 UTC+0200 Przemyslaw Czerpak (druzus/at/poczta.onet.pl)

### DIFF
--- a/src/vm/classes.c
+++ b/src/vm/classes.c
@@ -2269,7 +2269,7 @@ HB_BOOL hb_objGetVarRef( PHB_ITEM pObject, PHB_SYMB pMessage,
       {
          pExecSym->value.pFunPtr();
       }
-      else
+      else if( pStack->uiClass )
       {
          PCLASS pClass   = s_pClasses[ pStack->uiClass ];
          PMETHOD pMethod = pClass->pMethods + pStack->uiMethod;


### PR DESCRIPTION
  * src/vm/classes.c ! fixed GPF when object item variable is passed by reference but the object is neither instance of standard class nor scalar class